### PR TITLE
improve docs to make it easier to explain

### DIFF
--- a/tiddlers/Make a PR.tid
+++ b/tiddlers/Make a PR.tid
@@ -15,17 +15,19 @@ title: Make a PR
 
 \define targetRepo()
 <$select tiddler="$:/config/sq/makepr/repoOwner" default="">
-<option value="jermolene">official TW repository</option>
-<option value="twlinks-ci-test">test repository</option>
+<option value="jermolene">Official TW Repository</option>
+<option value="twlinks-ci-test">Test Repository</option>
 </$select>
 \end
+
+For more info about this form read the [[Notes]]
+
+---
 
 Automatically add new and modified tiddlers to the PR: <$select tiddler="$:/config/sq/makepr/autotrack" default='yes'>
 <option value="yes">yes</option>
 <option value="no">no</option>
 </$select>
-
-
 
 |tc-import-table tc-edit-field-value pr-table|k
 |Target repository |<<targetRepo>> |

--- a/tiddlers/Notes.tid
+++ b/tiddlers/Notes.tid
@@ -4,22 +4,49 @@ tags:
 title: Notes
 type: text/vnd.tiddlywiki
 
-* The UI here is simple but it has the basic necessities and the process works.
-* In order to create a PR (Pull Request) you will need
-** An account at //~GitHub//
-** [[A GitHub personal access token|https://github.com/settings/tokens/new?scopes=public_repo]]
-* This //~TiddlyWiki// file contains a copy of tiddlywiki.com. You can edit tiddlers and create tiddlers and then submit them via the supplied [[form|Make a PR]] . 
-** You can drag and drop tiddlers from under the `Open` or `Recent` sidebar tabs into the `Tiddlers to include` box on the form.
-** New tiddlers will need to have a physical path specified from the path select box. The box only appears if there are brand new tiddlers to be specified
-** If you are unsure what path to specify for new tiddlers, you can look at the path for existing "neighbor" tiddlers from the Table Of Contents.
-** To see the file path of an existing tiddler click on  the down arrow at the top right of the tiddler, then click on the //info// button. Then on the //sources// tab. The path portion listed after `tw5.com.tiddlers/` is the physical path of that tiddler. 
-** As a precaution, consider saving your work to your local hard drive, possibly using the [[fallback saver|https://tiddlywiki.com/#Saving%20with%20the%20HTML5%20fallback%20saver]] mechanism.
+The UI in the [[Contribution Form|Make a PR]] here is simple but it has the basic necessities and the process works.
+
+!! Preparations
+
+* You will need an account at [ext[https://GitHub.com]]
+* You need to [[sign the Contributor License Agreement (CLA)|https://tiddlywiki.com/#Signing%20the%20Contributor%20License%20Agreement]]
+* You need [[a GitHub personal access token|https://github.com/settings/tokens/new?scopes=public_repo]], so this wiki is allowed to create a pull request from your browser
+
+!! Prepare you changes
+
+This //~TiddlyWiki// file contains a copy of tiddlywiki.com. You can edit and create tiddlers to submit them via the [[contribution form|Make a PR]].
+
+* You can drag and drop tiddlers from under the `Open` or `Recent` sidebar tabs into the `Tiddlers to include` box on the form.
+
+* New tiddlers will need to have a physical path specified from the path select box.<br/>The box only appears if there are brand new tiddlers to be specified
+
+* If you are unsure what path to specify for new tiddlers, you can look at the path for existing "neighbor" tiddlers from the Table Of Contents.
+
+* To see the file path of an existing tiddler click on  the down arrow at the top right of the tiddler.
+** Then click on the //info// button. 
+** Select the //sources// tab.
+** The path portion listed after `tw5.com.tiddlers/` is the physical path of that tiddler.
+
+!! Backup your changes
+
+Having a backup, will make it easy to create a new PR, if the first one needs some changes
+
+* You can use the export preview button @@.pr-inline-button {{$:/core/images/export-button}}@@ to list all edited tiddlers and the form configuration in ~$:/AdvancedSearch
+* From there you can export / backup all of them as a JSON file
+
+!! Create a pull request (PR)
+
 * PRs are intentionally created against a test repository by default to avoid spamming the main repo while testing.
-** To make a PR against the main TiddlyWiki repository, use the dropdown to select the "Target Repository"
-** In order for your PR to be accepted at the main repository, you will need to [[sign the Contributor License Agreement|https://tiddlywiki.com/#Signing%20the%20Contributor%20License%20Agreement]]
+
+* To make a PR against the main ~TiddlyWiki repository, use the "Target Repository" dropdown and select the "Official TW Repository"
+
+* In order for your PR to be accepted at the main repository, you will need to sign the Contributor License Agreement (CLA). See Preparations
+
 * If the "Make a PR" button is disabled, make sure you have filled out the PR title and message
 
 ---
+
+''TODO''
 
 * File deletion/renaming.
 * Control of branch naming?

--- a/tiddlers/PR Styles.tid
+++ b/tiddlers/PR Styles.tid
@@ -16,6 +16,7 @@ table.pr-table > tbody > tr > td:nth-child(1) {
 
 .pr-listmode-btn {
 	float: right;
+	padding-left: .5em;
 }
 
 .pr-tiddlers .tc-droppable > .pr-list-placeholder {
@@ -23,13 +24,15 @@ table.pr-table > tbody > tr > td:nth-child(1) {
 	padding: 1em;
 }
 
+.pr-inline-button {
+  width: 1.2em; 
+  vertical-align:-1ex; 
+  display:inline-block; 
+}
 
 /*
-
 strike through for icons
 
 background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg' preserveAspectRatio='none'%3e%3cline x1='0' y1='100' x2='100' y2='0' stroke-width='8' stroke='%230B2437'/%3e%3c/svg%3e");
     background-size: 100% 100%;
-	
-	
 */

--- a/tiddlers/pr-tiddler-list.tid
+++ b/tiddlers/pr-tiddler-list.tid
@@ -2,6 +2,14 @@ title: $:/plugins/sq/makepr/pr-tiddler-list
 
 \define pr-tiddler-list() $:/temp/pr-tiddlers
 
+\define advanced-filter() [[$:/temp/pr-tiddlers]get[text]enlist-input[]] [[$:/temp/pr-tiddlers]get[text]enlist-input[]addprefix[$:/temp/prpath-]] [prefix[$:/temp/pr-]] [prefix[$:/config/sq/makepr/]]
+
+\define show-in-search() 
+<$action-setfield $tiddler="$:/temp/advancedsearch" text=<<advanced-filter>>/>
+<$action-setfield $tiddler="$:/temp/advancedsearch/input" text=<<advanced-filter>>/>
+<$action-setfield $tiddler="$:/state/tab--1498284803" text="$:/core/ui/AdvancedSearch/Filter"/>
+<$action-navigate $to="$:/AdvancedSearch"/>
+\end
 
 \define drop-actions()
 <$action-listops $tiddler=<<pr-tiddler-list>> $field="text" $subfilter="+[insertbefore:currentTiddler<actionTiddler>]"/>
@@ -28,6 +36,7 @@ title: $:/plugins/sq/makepr/pr-tiddler-list
 <$droppable tag="div" actions=<<drop-actions>> enable="yes">
 //Drag and drop below to add tiddlers://
 <$button class="tc-btn-invisible pr-listmode-btn" set="$:/state/pr-list-mode" setTo="text" tooltip="use text editor">{{$:/core/images/edit-button}}</$button>
+<$button class="tc-btn-invisible pr-listmode-btn" tooltip="Show list in $:/AdvancedSearch to export" actions=<<show-in-search>>>{{$:/core/images/export-button}}</$button>
 <$list filter="[<pr-tiddler-list>get[text]enlist-input[]]" history=<<tv-history-list>> storyview="pop">
 <div class="tc-sidebar-tab-open-item">
 <$macrocall $name="droppable-item"/>

--- a/tiddlywiki.info
+++ b/tiddlywiki.info
@@ -10,58 +10,23 @@
 	],
     "build": {
         "index": [
-            "--rendertiddler",
-            "$:/core/save/all",
-            "index.html",
-            "text/plain"
+            "--rendertiddler", "$:/core/save/all", "index.html", "text/plain"
         ],
         "empty": [
-            "--rendertiddler",
-            "$:/core/save/all",
-            "empty.html",
-            "text/plain",
-            "--rendertiddler",
-            "$:/core/save/all",
-            "empty.hta",
-            "text/plain"
+            "--rendertiddler", "$:/core/save/all", "empty.html", "text/plain",
+            "--rendertiddler", "$:/core/save/all", "empty.hta", "text/plain"
         ],
         "externalimages": [
-            "--savetiddlers",
-            "[is[image]]",
-            "images",
-            "--setfield",
-            "[is[image]]",
-            "_canonical_uri",
-            "$:/core/templates/canonical-uri-external-image",
-            "text/plain",
-            "--setfield",
-            "[is[image]]",
-            "text",
-            "",
-            "text/plain",
-            "--rendertiddler",
-            "$:/core/save/all",
-            "externalimages.html",
-            "text/plain"
+            "--savetiddlers", "[is[image]]", "images",
+            "--setfield", "[is[image]]", "_canonical_uri", "$:/core/templates/canonical-uri-external-image", "text/plain",
+            "--setfield", "[is[image]]", "text", "", "text/plain",
+            "--rendertiddler", "$:/core/save/all", "externalimages.html", "text/plain"
         ],
         "static": [
-            "--rendertiddler",
-            "$:/core/templates/static.template.html",
-            "static.html",
-            "text/plain",
-            "--rendertiddler",
-            "$:/core/templates/alltiddlers.template.html",
-            "alltiddlers.html",
-            "text/plain",
-            "--rendertiddlers",
-            "[!is[system]]",
-            "$:/core/templates/static.tiddler.html",
-            "static",
-            "text/plain",
-            "--rendertiddler",
-            "$:/core/templates/static.template.css",
-            "static/static.css",
-            "text/plain"
+            "--rendertiddler", "$:/core/templates/static.template.html", "static.html", "text/plain",
+            "--rendertiddler", "$:/core/templates/alltiddlers.template.html", "alltiddlers.html", "text/plain",
+            "--rendertiddlers", "[!is[system]]", "$:/core/templates/static.tiddler.html", "static", "text/plain",
+            "--rendertiddler", "$:/core/templates/static.template.css", "static/static.css", "text/plain"
         ]
     }
 }


### PR DESCRIPTION
I'm about to create some videos to explain the: Make a PR with TiddlyWiki workflow. ... It turns out, that the existing Notes should have a more "straight forward" structure to make the explanation easy. 

Notes links to the Make PR form now and the form links back to Notes. Which makes it easier if you close one of them. 

The new Notes looks as follows. I think it is easier to read now.

![grafik](https://user-images.githubusercontent.com/374655/155724054-f839c044-d3eb-44ac-941b-55364c8d36fc.png)

The Make a PR tiddler got a new button, to allow us to make a backup including the PR settings and the changed tiddlers. There is still some room for improvement here. 

![grafik](https://user-images.githubusercontent.com/374655/155724389-7fef3df7-9f9c-4a2b-85cb-071c400cd441.png)

-------

I intend to create a series of videos, where the first 3 are GitHub related and can also be used "stand alone" to help new contributors. 4, 5 and 6 should show the TW related workflow. 

 1. Create a GitHub account
 2. Sign the CLA
 3. Create a personal auth token
 4. Prepare your work and backup
 5. Create a PR ... I will create a real PR, improving the [sortan operator docs](https://tiddlywiki.com/#sortan%20Operator:%5B%5Bsortan%20Operator%5D%5D%20%5B%5Bsortan%20Operator%20(Examples)%5D%5D%20Apple) in the main TW repo.
 6. What if the PR needs to be changed ...... 
    6.1. Use the backup to create a new PR
    6.2. This can be changed into "How to create changes for an existing PR" when we know how to do this
 8. Explain in more detail, what's going on. ... Info about repos, forks, branches ... 
