### PR TITLE
change cnd URL as shown in the docs

### DIFF
--- a/tiddlers/makepr.js
+++ b/tiddlers/makepr.js
@@ -98,9 +98,9 @@ exports.startup = function() {
 			console.log(files);
 			if(!$tw.Octokit) {
  			  	$tw.wiki.addTiddler(new $tw.Tiddler({title: STATUS_TITLE, text: `loading Octokit library`}));
-				import("https://cdn.pika.dev/@octokit/core").then((module)=>{
+				import("https://cdn.skypack.dev/@octokit/core").then((module)=>{
 					$tw.Octokit = module.Octokit;
-					return import("https://cdn.pika.dev/octokit-plugin-create-pull-request");
+					return import("https://cdn.skypack.dev/octokit-plugin-create-pull-request");
 				}).then((module)=>{
 					$tw.createPullRequest = module.createPullRequest;
 					makepr(files,slug);


### PR DESCRIPTION
change cnd URL as shown in [the docs](https://github.com/octokit/core.js#readme). 

Also see:  https://cdn.skypack.dev/@octokit/core, which shows: 

```
/*
 * Skypack CDN - @octokit/core@3.5.1
 *
 * Learn more:
 *   📙 Package Documentation: https://www.skypack.dev/view/@octokit/core
 *   📘 Skypack Documentation: https://www.skypack.dev/docs
 *
 * Pinned URL: (Optimized for Production)
 *   ▶️ Normal: https://cdn.skypack.dev/pin/@octokit/core@v3.5.1-uyPy20XeRU5LgCe0jcpN/mode=imports/optimized/@octokit/core.js
 *   ⏩ Minified: https://cdn.skypack.dev/pin/@octokit/core@v3.5.1-uyPy20XeRU5LgCe0jcpN/mode=imports,min/optimized/@octokit/core.js
 *
 */

May be we should directly include the pinned minified version. It won't change library version by accident. 
```